### PR TITLE
Switch to using GestureDetector instead of Listener

### DIFF
--- a/lib/src/ui/reaction_button.dart
+++ b/lib/src/ui/reaction_button.dart
@@ -1,9 +1,6 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import '../models/reaction.dart';
-import '../utils/constants.dart';
 import '../utils/extensions.dart';
 import '../utils/reactions_position.dart';
 import 'reactions_box.dart';
@@ -22,10 +19,10 @@ class ReactionButton<T> extends StatefulWidget {
   /// Offset to add to the placement of the box
   final Offset boxOffset;
 
-  /// Vertical position reactions box according to the button [default = VerticalPosition.TOP]
+  /// Vertical position of the reactions box relative to the button [default = VerticalPosition.TOP]
   final VerticalPosition boxPosition;
 
-  /// Horizontal position reactions box according to the button [default = HorizontalPosition.START]
+  /// Horizontal position of the reactions box relative to the button [default = HorizontalPosition.START]
   final HorizontalPosition boxHorizontalPosition;
 
   /// Reactions box color [default = white]
@@ -83,8 +80,6 @@ class _ReactionButtonState<T> extends State<ReactionButton<T>> {
 
   Reaction? _selectedReaction;
 
-  Timer? _timer;
-
   void _init() {
     _selectedReaction = widget.initialReaction;
   }
@@ -102,43 +97,13 @@ class _ReactionButtonState<T> extends State<ReactionButton<T>> {
   }
 
   @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Listener(
-      key: _buttonKey,
-      onPointerDown: (details) {
-        _onTapReactionButton(details.position);
-      },
-      onPointerUp: (details) {
-        if (_timer?.isActive ?? false) {
-          _timer?.cancel();
-          _timer = null;
-          _onTapReactionButton(details.position);
-        }
-      },
-      onPointerMove: (_) {
-        _timer?.cancel();
-        _timer = null;
-      },
-      child: (_selectedReaction ?? widget.reactions.first).icon,
-    );
-  }
-
-  void _onTapReactionButton(Offset offset) {
-    if (_timer != null) return;
-    _timer = Timer(
-      KTapListenDuration,
-      () {
-        _timer = null;
-        _showReactionsBox(offset);
-      },
-    );
-  }
+  Widget build(BuildContext context) => GestureDetector(
+        key: _buttonKey,
+        behavior: HitTestBehavior.translucent,
+        onTapDown: (details) => _showReactionsBox(details.globalPosition),
+        onLongPressStart: (details) => _showReactionsBox(details.globalPosition),
+        child: (_selectedReaction ?? widget.reactions.first).icon,
+      );
 
   void _showReactionsBox(Offset buttonOffset) async {
     final buttonSize = _buttonKey.widgetSize;

--- a/lib/src/ui/reaction_button_toggle.dart
+++ b/lib/src/ui/reaction_button_toggle.dart
@@ -1,9 +1,6 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import '../models/reaction.dart';
-import '../utils/constants.dart';
 import '../utils/extensions.dart';
 import '../utils/reactions_position.dart';
 import 'reactions_box.dart';
@@ -25,10 +22,10 @@ class ReactionButtonToggle<T> extends StatefulWidget {
   /// Offset to add to the placement of the box
   final Offset boxOffset;
 
-  /// Vertical position reactions box for the button [default = TOP]
+  /// Vertical position of the reactions box relative to the button [default = VerticalPosition.TOP]
   final VerticalPosition boxPosition;
 
-  /// Horizontal position reactions box relative to the button [default = START]
+  /// Horizontal position of the reactions box relative to the button [default = HorizontalPosition.START]
   final HorizontalPosition boxHorizontalPosition;
 
   /// Reactions box color [default = white]
@@ -88,14 +85,11 @@ class _ReactionButtonToggleState<T> extends State<ReactionButtonToggle<T>> {
 
   Reaction<T>? _selectedReaction;
 
-  Timer? _timer;
-
   bool _isChecked = false;
 
   void _init() {
     _isChecked = widget.isChecked;
-    _selectedReaction =
-        _isChecked ? widget.selectedReaction : widget.initialReaction;
+    _selectedReaction = _isChecked ? widget.selectedReaction : widget.initialReaction;
   }
 
   @override
@@ -111,50 +105,18 @@ class _ReactionButtonToggleState<T> extends State<ReactionButtonToggle<T>> {
   }
 
   @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Listener(
-      key: _buttonKey,
-      onPointerDown: (details) {
-        _onTapReactionButton(details.position);
-      },
-      onPointerUp: (_) {
-        if (_timer?.isActive ?? false) {
-          _timer?.cancel();
-          _timer = null;
-          _onClickReactionButton();
-        }
-      },
-      onPointerMove: (_) {
-        _timer?.cancel();
-        _timer = null;
-      },
-      child: (_selectedReaction ?? widget.reactions[0])!.icon,
-    );
-  }
-
-  void _onTapReactionButton(Offset offset) {
-    if (_timer != null) return;
-    _timer = Timer(
-      KTapListenDuration,
-      () {
-        _timer = null;
-        _showReactionsBox(offset);
-      },
-    );
-  }
+  Widget build(BuildContext context) => GestureDetector(
+        key: _buttonKey,
+        behavior: HitTestBehavior.translucent,
+        onTap: _onClickReactionButton,
+        onLongPressStart: (details) => _showReactionsBox(details.globalPosition),
+        child: (_selectedReaction ?? widget.reactions[0])!.icon,
+      );
 
   void _onClickReactionButton() {
     _isChecked = !_isChecked;
     _updateReaction(
-      _isChecked
-          ? widget.selectedReaction ?? widget.reactions[0]
-          : widget.initialReaction,
+      _isChecked ? widget.selectedReaction ?? widget.reactions[0] : widget.initialReaction,
     );
   }
 
@@ -192,8 +154,7 @@ class _ReactionButtonToggleState<T> extends State<ReactionButtonToggle<T>> {
     Reaction<T>? reaction, [
     bool isSelectedFromDialog = false,
   ]) {
-    _isChecked =
-        isSelectedFromDialog ? true : reaction != widget.initialReaction;
+    _isChecked = isSelectedFromDialog ? true : reaction != widget.initialReaction;
     widget.onReactionChanged.call(
       reaction?.value,
       _isChecked,

--- a/lib/src/ui/reaction_container.dart
+++ b/lib/src/ui/reaction_container.dart
@@ -1,13 +1,10 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import '../models/reaction.dart';
-import '../utils/constants.dart';
 import '../utils/reactions_position.dart';
 import 'reactions_box.dart';
 
-class ReactionContainer<T> extends StatefulWidget {
+class ReactionContainer<T> extends StatelessWidget {
   /// This triggers when reaction button value changed.
   final void Function(T?) onReactionChanged;
 
@@ -16,10 +13,10 @@ class ReactionContainer<T> extends StatefulWidget {
 
   final List<Reaction<T>?> reactions;
 
-  /// Vertical position reactions box according to the button [default = VerticalPosition.TOP]
+  /// Vertical position of the reactions box relative to the button [default = VerticalPosition.TOP]
   final VerticalPosition boxPosition;
 
-  /// Horizontal position reactions box according to the button [default = HorizontalPosition.START]
+  /// Horizontal position of the reactions box relative to the button [default = HorizontalPosition.START]
   final HorizontalPosition boxHorizontalPosition;
 
   /// Reactions box color [default = white]
@@ -63,50 +60,15 @@ class ReactionContainer<T> extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _ReactionContainerState createState() => _ReactionContainerState<T>();
-}
-
-class _ReactionContainerState<T> extends State<ReactionContainer<T>> {
-  Timer? _timer;
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return Listener(
-      onPointerDown: (details) {
-        _onTapReactionButton(details.position);
-      },
-      onPointerUp: (_) {
-        if (_timer?.isActive ?? false) {
-          _timer?.cancel();
-          _timer = null;
-        }
-      },
-      onPointerMove: (_) {
-        _timer?.cancel();
-        _timer = null;
-      },
-      child: widget.child,
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onLongPressStart: (details) => _showReactionsBox(context, details.globalPosition),
+      child: child,
     );
   }
 
-  void _onTapReactionButton(Offset offset) {
-    if (_timer != null) return;
-    _timer = Timer(
-      KTapListenDuration,
-      () {
-        _timer = null;
-        _showReactionsBox(offset);
-      },
-    );
-  }
-
-  void _showReactionsBox(Offset buttonOffset) async {
+  void _showReactionsBox(BuildContext context, Offset buttonOffset) async {
     final reactionButton = await Navigator.of(context).push(
       PageRouteBuilder(
         opaque: false,
@@ -115,22 +77,21 @@ class _ReactionContainerState<T> extends State<ReactionContainer<T>> {
           return ReactionsBox(
             buttonOffset: buttonOffset,
             buttonSize: Size.zero,
-            reactions: widget.reactions,
-            verticalPosition: widget.boxPosition,
-            horizontalPosition: widget.boxHorizontalPosition,
-            color: widget.boxColor,
-            elevation: widget.boxElevation,
-            radius: widget.boxRadius,
-            duration: widget.boxDuration,
-            boxPadding: widget.boxPadding,
-            itemScale: widget.itemScale,
-            itemScaleDuration: widget.itemScaleDuration,
+            reactions: reactions,
+            verticalPosition: boxPosition,
+            horizontalPosition: boxHorizontalPosition,
+            color: boxColor,
+            elevation: boxElevation,
+            radius: boxRadius,
+            duration: boxDuration,
+            boxPadding: boxPadding,
+            itemScale: itemScale,
+            itemScaleDuration: itemScaleDuration,
           );
         },
       ),
     );
 
-    if (reactionButton != null)
-      widget.onReactionChanged.call(reactionButton.value);
+    if (reactionButton != null) onReactionChanged.call(reactionButton.value);
   }
 }

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -1,1 +1,0 @@
-const Duration KTapListenDuration = Duration(milliseconds: 100);


### PR DESCRIPTION
Currently, if the button is in a scrollable area, it is sometimes hard to press the button without triggering the `Listener.onPointerMove` that resets the timer. This PR uses Flutter's own widget for long press detection that catches these things and is also easier to understand. Furthermore, it should fix #31.