### PR TITLE
Fixing failed builds for iOS

### DIFF
--- a/lib/src/ui/widget_size_render_object.dart
+++ b/lib/src/ui/widget_size_render_object.dart
@@ -33,7 +33,7 @@ class _WidgetSizeRenderObject extends RenderProxyBox {
 
       if (newSize != null && currentSize != newSize) {
         currentSize = newSize;
-        WidgetsBinding.instance.addPostFrameCallback((_) {
+        WidgetsBinding.instance?.addPostFrameCallback((_) {
           onSizeChange(newSize);
         });
       }


### PR DESCRIPTION
I'm getting the following error when building the most recent release on an iOS device.

```
    ../../../.asdf/installs/flutter/2.10.4-stable/.pub-cache/hosted/pub.dartlang.org/flutter_reaction_button-2.0.1+1/lib/src/ui/widget_size_render_object.dart:36:33: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
     - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../../.asdf/installs/flutter/2.10.4-stable/packages/flutter/lib/src/widgets/binding.dart').
    Try calling using ?. instead.
            WidgetsBinding.instance.addPostFrameCallback((_) {
                                    ^^^^^^^^^^^^^^^^^^^^
    Failed
```

The suggested change is working for me.

I believe this bug was introduced in this PR: https://github.com/GeekAbdelouahed/flutter-reaction-button/pull/38/files

I'm on flutter 2.10.4 - that change was likely made for 3.0.0.