### PR TITLE
Fixed warnings 

### DIFF
--- a/lib/src/ui/widget_size_render_object.dart
+++ b/lib/src/ui/widget_size_render_object.dart
@@ -33,7 +33,7 @@ class _WidgetSizeRenderObject extends RenderProxyBox {
 
       if (newSize != null && currentSize != newSize) {
         currentSize = newSize;
-        WidgetsBinding.instance?.addPostFrameCallback((_) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
           onSizeChange(newSize);
         });
       }


### PR DESCRIPTION
Related to Warning: Operand of null-aware operation '?.' has type 'WidgetsBinding' which excludes null.